### PR TITLE
Add CI workflow to build Kotlin project

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,0 +1,19 @@
+name: Kotlin CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - name: Build with Gradle
+        run: ./gradlew build --no-daemon


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that builds the Kotlin project using Gradle

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_688e3b26bfd88320a0a0db015f747770